### PR TITLE
Update templates

### DIFF
--- a/templates/build_failed.md.erb
+++ b/templates/build_failed.md.erb
@@ -1,3 +1,3 @@
-Our automated Travis CI test suite found some issues with your submission.
+Our automated test system found some issues with your submission. Please inspect the [test report]() and make sure your styles follow all our [Style Requirements](https://github.com/citation-style-language/styles/wiki/Style-Requirements).
 
-You can update this pull request by visiting the style link(s) above and clicking the pencil icon.
+You can update this pull request by visiting the "Files changed" tab above, clicking the "View" button of the file you wish to change, and finally clicking the pencil icon.

--- a/templates/build_passed.md.erb
+++ b/templates/build_passed.md.erb
@@ -1,3 +1,1 @@
-Congratulations! Your submission passed our automated Travis CI test suite.
-
-@rmzelle @adam3smith please take over!
+Good news! Your pull request passed all our automated tests. Our volunteers will try to take a look soon.

--- a/templates/pull_request_opened.md.erb
+++ b/templates/pull_request_opened.md.erb
@@ -1,9 +1,7 @@
-Thank you @<%= user['login'] %> for submitting to the Citation Styles Language repository. Shortly, our automated test suite will check your submission to ensure that there are no formal errors.
+Thank you for your submission to the Citation Styles Language styles repository.
 
-Please make sure that your filename, id, and link follows the conventions outlined in 1,2,4,5,6 [here](https://github.com/citation-style-language/styles/wiki/Style-Requirements).
+Our automated test system will now run checks on your pull request to detect some common problems. E.g. it makes sure your styles are correctly named and validate against the CSL schema. You will be notified when the test report is ready, which usually takes just a few minutes.
 
-While not technically required, we also ask that you include a link to online documentation for the style with `rel="documentation"` as per 10.  [here](https://github.com/citation-style-language/styles/wiki/Style-Requirements).
+The volunteers who maintain this repository and are in charge of accepting styles into the repository will also take a look, which can take a day or two. We might ask you to make some additional changes to make sure your styles follow all our [Style Requirements](https://github.com/citation-style-language/styles/wiki/Style-Requirements).
 
-You can update your pull request by editing your style [here](<%= head['repo']['html_url'] %>).  Click the pencil icon at the top right of that page.
-
-Feel free to post here if you need any help.
+If you need assistance at any point, please leave a comment and we'll get back to you. Feel free to write in Spanish, German, or Dutch if that's easier for you.


### PR DESCRIPTION
In response to https://github.com/citation-style-language/utilities/issues/20#issuecomment-121553254

The PR contains an empty link to the Travis build report (`[test report]()`). We should be able to get that link, right? 
